### PR TITLE
Remove dark mode option

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,18 +69,7 @@
         <div class="title left">
           Web Bluetooth Dashboard
         </div>
-        <div class="right">
-          <label for="darkmode">
-            Dark Mode
-          </label>
-          <div class="onoffswitch">
-            <input type="checkbox" name="darkmode" class="onoffswitch-checkbox" id="darkmode">
-            <label class="onoffswitch-label" for="darkmode">
-              <span class="onoffswitch-inner"></span>
-              <span class="onoffswitch-switch"></span>
-            </label>
-          </div>
-        </div>
+        <!-- Dark mode controls removed -->
       </div>
       <div id="dashboard"></div>
       <div id="log"></div>

--- a/js/script.js
+++ b/js/script.js
@@ -25,8 +25,6 @@ const butClear = document.getElementById('butClear');
 const autoscroll = document.getElementById('autoscroll');
 const showTimestamp = document.getElementById('showTimestamp');
 const lightSS = document.getElementById('light');
-const darkSS = document.getElementById('dark');
-const darkMode = document.getElementById('darkmode');
 const dashboard = document.getElementById('dashboard');
 const fpsCounter = document.getElementById("fpsCounter");
 const knownOnly = document.getElementById("knownonly");
@@ -42,7 +40,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   butClear.addEventListener('click', clickClear);
   autoscroll.addEventListener('click', clickAutoscroll);
   showTimestamp.addEventListener('click', clickTimestamp);
-  darkMode.addEventListener('click', clickDarkMode);
   knownOnly.addEventListener('click', clickKnownOnly);
 
   if ('bluetooth' in navigator) {
@@ -562,7 +559,7 @@ function logMsg(text) {
 
 /**
  * @name updateTheme
- * Sets the theme to  Adafruit (dark) mode. Can be refactored later for more themes
+ * Sets the theme to light mode. Can be refactored later for more themes
  */
 function updateTheme() {
   // Disable all themes
@@ -572,11 +569,7 @@ function updateTheme() {
       enableStyleSheet(styleSheet, false);
     });
 
-  if (darkMode.checked) {
-    enableStyleSheet(darkSS, true);
-  } else {
-    enableStyleSheet(lightSS, true);
-  }
+  enableStyleSheet(lightSS, true);
 }
 
 function enableStyleSheet(node, enabled) {
@@ -658,17 +651,6 @@ async function clickTimestamp() {
 }
 
 /**
- * @name clickDarkMode
- * Change handler for the Dark Mode checkbox.
- */
-async function clickDarkMode() {
-  updateTheme();
-  saveSetting('darkmode', darkMode.checked);
-}
-
-
-
-/**
  * @name clickKnownOnly
  * Change handler for the Show Only Known Devices checkbox.
  */
@@ -705,7 +687,6 @@ function loadAllSettings() {
   // Load all saved settings or defaults
   autoscroll.checked = loadSetting('autoscroll', true);
   showTimestamp.checked = loadSetting('timestamp', false);
-  darkMode.checked = loadSetting('darkmode', true);
   knownOnly.checked = loadSetting('knownonly', true);
 }
 


### PR DESCRIPTION
## Summary
- hide dark mode switch in the dashboard
- always use the light theme

## Testing
- `npm test` *(fails: Could not read package.json)*
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687d4b0987ac8324968acdaf6e80af68